### PR TITLE
Add pydocstyle to the pre-commit hooks.

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,3 +47,8 @@ repos:
       hooks:
           - id: pyupgrade
             args: [--py38-plus]
+
+    - repo: https://github.com/pycqa/pydocstyle
+      rev: 6.1.1  # pick a git hash / tag to point to
+      hooks:
+          - id: pydocstyle


### PR DESCRIPTION
This adds standard checks about how doc-strings should be formatted and ideally formulated.