### PR TITLE
Allow passing of MarketPlaceClient instance during app instantiation.

### DIFF
--- a/marketplace/app/__init__.py
+++ b/marketplace/app/__init__.py
@@ -4,6 +4,7 @@ capabilities.
 .. moduleauthor:: Pablo de Andres, Pranjali Singh (Fraunhofer IWM)
 """
 import warnings
+from typing import Optional
 
 from packaging.version import parse
 
@@ -22,7 +23,7 @@ class MarketPlaceApp(_MarketPlaceApp_v0_0_1):
         super().__init__(*args, **kwargs)
 
 
-def get_app(app_id, marketplace_host_url=None, access_token=None, **kwargs):
+def get_app(app_id, client: Optional[MarketPlaceClient] = None, **kwargs):
     """Get an app instance.
     Args:
         app_id (str): client id of the app
@@ -30,12 +31,9 @@ def get_app(app_id, marketplace_host_url=None, access_token=None, **kwargs):
     Returns:
         MarketPlaceApp: app instance
     """
-    client = MarketPlaceClient(
-        marketplace_host_url=marketplace_host_url, access_token=access_token
-    )
+    client = client or MarketPlaceClient()
 
     # Getting api version and list of capabilities for the application
-
     app_service_path = f"api/applications/{app_id}"
     app_info = client.get(path=app_service_path).json()
     app_api_version = parse(app_info["api_version"])
@@ -45,15 +43,19 @@ def get_app(app_id, marketplace_host_url=None, access_token=None, **kwargs):
         capabilities.append(camel_to_snake(capability["name"]))
 
     if app_api_version == parse("0.0.1"):
+        if client is not None:
+            raise RuntimeError(
+                "Cannot use existing client for apps with API version 0.0.1."
+            )
         return _MarketPlaceApp_v0_0_1(
             app_id,
-            marketplace_host_url=marketplace_host_url,
-            access_token=access_token,
+            marketplace_host_url=kwargs.get("marketplace_host_url"),
+            access_token=kwargs.get("access_token"),
             capabilities=capabilities,
             **kwargs,
         )
     elif parse("0.0.1") < app_api_version <= parse("0.3.0"):
-        return _MarketPlaceApp_v0(client, app_id, app_info, **kwargs)
+        return _MarketPlaceApp_v0(app_id, app_info, client, **kwargs)
     else:
         raise RuntimeError(f"App API version ({app_api_version}) not supported.")
 

--- a/marketplace/app/v0/base.py
+++ b/marketplace/app/v0/base.py
@@ -1,4 +1,5 @@
 import json
+from typing import Optional
 from urllib.parse import urljoin
 
 from fastapi.responses import HTMLResponse
@@ -10,8 +11,10 @@ from ..utils import camel_to_snake, check_capability_availability
 
 
 class _MarketPlaceAppBase:
-    def __init__(self, client: MarketPlaceClient, app_id: str, app_info: dict):
-        self._client: MarketPlaceClient = client
+    def __init__(
+        self, app_id: str, app_info: dict, client: Optional[MarketPlaceClient] = None
+    ):
+        self._client: MarketPlaceClient = client or MarketPlaceClient()
         self.app_id: str = app_id
         self._app_info: dict = app_info
         self.capabilities = {


### PR DESCRIPTION
Instead of passing through client constructor arguments, we enable users
to instantiate the client and then pass that directly. This is an
improvement to the composition model as it does not require the
replication of client constructor arguments within the app constructor
function and also enables users to re-use an existing client instance.